### PR TITLE
アプリ起動直後の画面にボタンを3つ設置する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+/android/app/build

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,27 +34,42 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
+  Future<void> launchRandomPay() async {
+    final urls = [
+      'https://line.me/R/pay/generateQR',
+      "https://www.paypay.ne.jp/app/cashier",
+    ];
+    final select = Random().nextInt(urls.length);
+    final selectedUrl = urls[select];
+    if (Platform.isAndroid) {
+      AndroidIntent intent = AndroidIntent(
+        action: 'action_view',
+        data: selectedUrl,
+      );
+      await intent.launch();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: Center(
-        child: ElevatedButton(
-          child: const Text("起動する"),
-          onPressed: () async {
-            final urls = [
-              'https://line.me/R/pay/generateQR',
-              "https://www.paypay.ne.jp/app/cashier",
-            ];
-            final select = Random().nextInt(urls.length);
-            final selectedUrl = urls[select];
-            if (Platform.isAndroid) {
-              AndroidIntent intent = AndroidIntent(
-                action: 'action_view',
-                data: selectedUrl,
-              );
-              await intent.launch();
-            }
-          },
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ElevatedButton(
+              child: const Text("ファミリーマート"),
+              onPressed: launchRandomPay,
+            ),
+            ElevatedButton(
+              child: const Text("セブンイレブン"),
+              onPressed: launchRandomPay,
+            ),
+            ElevatedButton(
+              child: const Text("ローソン"),
+              onPressed: launchRandomPay,
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## やったこと
- ボタンを3つ設置する
  - それぞれに「ファミリーマート」「セブンイレブン」「ローソン」と文字を入れた
  - タップ時の挙動には既存のランダムにPayアプリを起動するメソッドを指定
- ランダムPay起動メソッドの有名化
  - 今まではボタンが一つだったので無名メソッドで良かったが、ボタンが増えたのでひとまず有名化した

<img src="https://user-images.githubusercontent.com/6907421/141979682-359ad344-670c-48cf-9a90-56767fcf61de.png" width="300px">