### PR TITLE
Firestore導入についてのドキュメント追加

### DIFF
--- a/docs/flutter-firestore.md
+++ b/docs/flutter-firestore.md
@@ -1,0 +1,10 @@
+# FlutterへのFirestoreの導入
+
+基本的な導入はできているが、鍵情報をGitHubにアップロードするのはセキュリティ上懸念が大きいので、各自でやってほしい。
+
+## Android
+
+1. https://console.firebase.google.com/project/chimimoryo/settings/general/android:com.example.chimimoryo_autumn へアクセス
+1. `google-services.json` をダウンロード
+1. このプロジェクトの `android/app` に置く (`android/app/google-services.json` になる)
+1. 完了


### PR DESCRIPTION
Firebaseへ接続するのに必要な鍵ファイルはGitHubにアップロードできないので、各自でダウンロードして設置してほしい。
その手順書。