### PR TITLE
店舗ごとのボタンを大量に出す

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -185,7 +185,10 @@ class _MyHomePageState extends State<MyHomePage> {
               builder: (context, snap) {
                 if (!snap.hasData) {
                   return Container();
-                } else {
+                if (!snap.hasData) {
+                    return Container():
+                final stores = snap.data;
+                ...
                   final stores = snap.data;
                   if (stores == null) {
                     return Container();

--- a/lib/models/pay.dart
+++ b/lib/models/pay.dart
@@ -1,0 +1,9 @@
+class Pay {
+  final String name;
+  final num benefit;
+
+  Pay({
+    required this.name,
+    required this.benefit,
+  });
+}

--- a/lib/models/store.dart
+++ b/lib/models/store.dart
@@ -1,0 +1,8 @@
+import 'package:chimimoryo_autumn/models/pay.dart';
+
+class Store {
+  final List<Pay> pays;
+  final String name;
+
+  Store({required this.name, required this.pays});
+}

--- a/lib/repository/store.dart
+++ b/lib/repository/store.dart
@@ -1,0 +1,34 @@
+import 'package:chimimoryo_autumn/models/pay.dart';
+import 'package:chimimoryo_autumn/models/store.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class StoreRepository {
+  late FirebaseFirestore firestore;
+
+  StoreRepository() {
+    firestore = FirebaseFirestore.instance;
+  }
+
+  Future<List<Store>> getStores() async {
+    /// __beta_1210/A94KOsRMgd5Sfk7JkI6u/Pays/0F7Jj4KRsnUB3oTTvLBe
+
+    final qSnap = await firestore.collection("__beta_1210").get();
+    print(qSnap.docs.length);
+    final storeFutures = qSnap.docs.map((doc) async {
+      final data = doc.data();
+      final storeName = data["store_name"];
+
+      final paysQSnap = await doc.reference.collection("Pays").get();
+      final pays = paysQSnap.docs.map((payDoc) {
+        final payData = payDoc.data();
+        return Pay(name: payData["pay_name"], benefit: payData["benefits"]);
+      });
+
+      return Store(name: storeName, pays: pays.toList());
+    });
+
+    final stores = await Future.wait(storeFutures);
+
+    return stores;
+  }
+}


### PR DESCRIPTION
Firestoreと連携して、店舗ごとのボタンを大量に出す。
ユーザは今いる店舗のボタンをタップすることで、最安の決済手段で決済することができる。

<img src="https://user-images.githubusercontent.com/6907421/146142929-fc02f012-c701-4f10-abc2-fa7c61e30a53.png" width="300">
