### PR TITLE
リリースできない問題の解決

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -57,7 +57,6 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
-//            signingConfig signingConfigs.config
             shrinkResources false
             minifyEnabled false
         }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -57,6 +57,9 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
+//            signingConfig signingConfigs.config
+            shrinkResources false
+            minifyEnabled false
         }
     }
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -62,4 +62,5 @@
             <data android:scheme="https"/>
         </intent>
     </queries>
+    <uses-permission android:name="android.permission.INTERNET" />
 </manifest>


### PR DESCRIPTION
## Motivation
- リリースできない問題を解決した。
- デバッグビルドだと起動するが、リリース用にビルドすると起動しない。

## Description of the changes
- リリースビルド時にインターネットアクセスできるようにした。
  - 📝 https://qiita.com/niusounds/items/7edbd21edaddd26ec905
- リリースビルド時に圧縮するオプションをオフにした。
  - 📝 https://stackoverflow.com/questions/49874194/flutter-release-apk-is-not-working-properly
  - 3MBほど大きくなったが、起動するようになった。
