### PR TITLE
位置情報に基づいて対応店舗をリスト表示する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ google-services.json
 
 # Secret file for firebase
 chimimoryo-firebase-adminsdk-*.json
+secret_const.dart

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -96,21 +96,6 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   void initState() {
     super.initState();
-    print("start get Location");
-    Future<Position> position = getLocation();
-    print("end get Location");
-    position.then((value) async {
-      print("緯度: " +
-          value.latitude.toString() +
-          "経度: " +
-          value.longitude.toString());
-      Set<String> storeListByLocation = await getStoreListByLocation(value);
-      final storeRepo = StoreRepository();
-      final storeListByDB = await storeRepo.getStores();
-      final filteredStoreList =
-          intersectionStores(storeListByLocation, storeListByDB);
-      print(filteredStoreList);
-    });
 
     HomeWidget.setAppGroupId('YOUR_GROUP_ID');
     HomeWidget.registerBackgroundCallback(backgroundCallback);
@@ -151,6 +136,23 @@ class _MyHomePageState extends State<MyHomePage> {
     "Lawson": {"Linepay": 2, "Paypay": 1},
     "FamilyMart": {"Linepay": 2, "Paypay": 1},
   };
+
+  Future<List<Store>> filteredStores() async {
+    print("start get Location");
+    Position position = await getLocation();
+    print("end get Location");
+    print("緯度: " +
+        position.latitude.toString() +
+        "経度: " +
+        position.longitude.toString());
+    Set<String> storeListByLocation = await getStoreListByLocation(position);
+    final storeRepo = StoreRepository();
+    final storeListByDB = await storeRepo.getStores();
+    final filteredStoreList =
+        intersectionStores(storeListByLocation, storeListByDB);
+    print(filteredStoreList);
+    return filteredStoreList.toList();
+  }
 
   Future<Position> getLocation() async {
     bool serviceEnabled;
@@ -198,14 +200,14 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Set<Store> intersectionStores(
       Set<String> storeListByLocation, List<Store> storeListByDB) {
-    var filterdStores = [];
+    var filteredStores = [];
     storeListByLocation.forEach((storeName) {
       final store = includeDB(storeName, storeListByDB);
       if (store != null) {
-        filterdStores.add(store);
+        filteredStores.add(store);
       }
     });
-    return Set.from(filterdStores);
+    return Set.from(filteredStores);
   }
 
   Store? includeDB(String storeName, List<Store> storeListByDB) {
@@ -272,7 +274,8 @@ class _MyHomePageState extends State<MyHomePage> {
           builder: (context) {
             final storeRepo = StoreRepository();
             return FutureBuilder<List<Store>>(
-              future: storeRepo.getStores(),
+              //future: storeRepo.getStores(),
+              future: filteredStores(),
               builder: (context, snap) {
                 if (!snap.hasData) {
                   return Container();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -138,19 +138,12 @@ class _MyHomePageState extends State<MyHomePage> {
   };
 
   Future<List<Store>> filteredStores() async {
-    print("start get Location");
     Position position = await getLocation();
-    print("end get Location");
-    print("緯度: " +
-        position.latitude.toString() +
-        "経度: " +
-        position.longitude.toString());
     Set<String> storeListByLocation = await getStoreListByLocation(position);
     final storeRepo = StoreRepository();
     final storeListByDB = await storeRepo.getStores();
     final filteredStoreList =
         intersectionStores(storeListByLocation, storeListByDB);
-    print(filteredStoreList);
     return filteredStoreList.toList();
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -177,6 +177,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.4"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.4"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.0"
   js:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   firebase_core: ^1.10.0
   fluttertoast: ^8.0.8
   geolocator: ^8.0.1
+  http: ^0.13.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Motivation
- 対応店舗全てをリスト表示してしまうとユーザーが探すのが大変．

## Description of the changes
- main.dartにfilterdStores含めて様々なメソッド追加
- .gitignoreにsecret_const.dart追加(yahooApiが記述)

## Next TODO(Option)
- ロード待ちをユーザに表示
- どのPayが起動するかをボタン状に表示
- 対応店舗がない場合に自動でどれかのPayが開く
