### PR TITLE
ロード中であることをユーザーに表示

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -271,7 +271,7 @@ class _MyHomePageState extends State<MyHomePage> {
               future: filteredStores(),
               builder: (context, snap) {
                 if (!snap.hasData) {
-                  return Container();
+                  return CircularProgressIndicator();
                 }
                 final stores = snap.data;
                 if (stores == null) {


### PR DESCRIPTION
## Motivation
- 位置情報などのロード中にユーザーがロード中なのかどうかわからない

## Description of the changes
- main.dartの widget buildに`CircularProgressIndicator()`を追加
