### PR TITLE
位置情報リロードボタンをAppBarに設置する

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -106,6 +106,9 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Future _init() async {
+    setState(() {
+      _storeList = null;
+    });
     final storeList = await filteredStores();
     setState(() {
       _storeList = storeList;
@@ -283,6 +286,14 @@ class _MyHomePageState extends State<MyHomePage> {
     return Scaffold(
       appBar: AppBar(
         title: const Text("近くのお店"),
+        actions: [
+          IconButton(
+            onPressed: () {
+              _init();
+            },
+            icon: const Icon(Icons.refresh, size: 30),
+          )
+        ],
       ),
       body: SafeArea(
         child: Column(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -102,10 +102,10 @@ class _MyHomePageState extends State<MyHomePage> {
     HomeWidget.setAppGroupId('YOUR_GROUP_ID');
     HomeWidget.registerBackgroundCallback(backgroundCallback);
 
-    _init();
+    _refreshStoreList();
   }
 
-  Future _init() async {
+  Future _refreshStoreList() async {
     setState(() {
       _storeList = null;
     });
@@ -289,7 +289,7 @@ class _MyHomePageState extends State<MyHomePage> {
         actions: [
           IconButton(
             onPressed: () {
-              _init();
+              _refreshStoreList();
             },
             icon: const Icon(Icons.refresh, size: 30),
           )


### PR DESCRIPTION
## Motivation
- 位置情報をリロードしたい
  - アプリを立ち上げ直したとき
  - 明らかに表示されるべき店舗が表示されていないとき

## Description of the changes
- AppBarにリロードボタンを設置して、押すと位置情報を取ってきてリストを表示しなおす
